### PR TITLE
Add port argument to AWSConnection object

### DIFF
--- a/awses/connection.py
+++ b/awses/connection.py
@@ -8,7 +8,7 @@ import os
 
 class AWSConnection(Connection):
 
-    def __init__(self, host, region, **kwargs):
+    def __init__(self, host, region, port=9200, **kwargs):
         super(AWSConnection, self).__init__(host, port, region, **kwargs)
         self.host = host
         self.region = region

--- a/awses/connection.py
+++ b/awses/connection.py
@@ -9,7 +9,7 @@ import os
 class AWSConnection(Connection):
 
     def __init__(self, host, region, **kwargs):
-        super(AWSConnection, self).__init__(host, region, **kwargs)
+        super(AWSConnection, self).__init__(host, port, region, **kwargs)
         self.host = host
         self.region = region
         self.token = kwargs['session_token'] if 'session_token' in kwargs else os.environ.get('AWS_SESSION_TOKEN')


### PR DESCRIPTION
I added a port argument to the AWSConnection constructor, and to the call to the parent Connection constructor.  If a port argument gets passed to Elasticsearch construtor upstream where AWSConnection is the connection_class, that arg gets passed in kwargs downstream to the Connection object and conflicts with the explicit port argument in its constructor.

```
"__init__() got multiple values for keyword argument 'port'"
```
